### PR TITLE
add -fcommon

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -19,7 +19,7 @@ oldincludedir = @oldincludedir@
 pdfdir = @pdfdir@
 prefix = @prefix@
 BASEDIR=@datadir@/0verkill
-CFLAGS += @CFLAGS@ -O3 @X_CFLAGS@ -DBASE_DIR="\"$(BASEDIR)\"" -Wall -W -Wstrict-prototypes -Wno-parentheses
+CFLAGS += @CFLAGS@ -O3 @X_CFLAGS@ -DBASE_DIR="\"$(BASEDIR)\"" -Wall -W -Wstrict-prototypes -Wno-parentheses -fcommon
 #-malign-functions=0
 LDFLAGS?=@LDFLAGS@
 LIBS=@LIBS@ 


### PR DESCRIPTION
Recent versions of gcc changed the default of `-fcommon` to `-fno-common`, which causes errors during linking:

```
/usr/bin/ld: data.o:/home/evan/resources/0verkill/data.c:43: multiple definition of `last_obj'; server.o:/home/evan/resources/0verkill/server.c:107: first defined here
/usr/bin/ld: data.o:/home/evan/resources/0verkill/data.h:185: multiple definition of `weapon'; server.o:/home/evan/resources/0verkill/data.h:185: first defined here
/usr/bin/ld: data.o:/home/evan/resources/0verkill/data.h:170: multiple definition of `obj_attr'; server.o:/home/evan/resources/0verkill/data.h:170: first defined here
/usr/bin/ld: data.o:/home/evan/resources/0verkill/data.h:142: multiple definition of `weapon_name'; server.o:/home/evan/resources/0verkill/data.h:142: first defined here
/usr/bin/ld: sprite.o:/home/evan/resources/0verkill/data.h:185: multiple definition of `weapon'; server.o:/home/evan/resources/0verkill/data.h:185: first defined here
/usr/bin/ld: sprite.o:/home/evan/resources/0verkill/data.h:170: multiple definition of `obj_attr'; server.o:/home/evan/resources/0verkill/data.h:170: first defined here
/usr/bin/ld: sprite.o:/home/evan/resources/0verkill/data.h:142: multiple definition of `weapon_name'; server.o:/home/evan/resources/0verkill/data.h:142: first defined here
/usr/bin/ld: hash.o:/home/evan/resources/0verkill/data.h:185: multiple definition of `weapon'; server.o:/home/evan/resources/0verkill/data.h:185: first defined here
/usr/bin/ld: hash.o:/home/evan/resources/0verkill/data.h:170: multiple definition of `obj_attr'; server.o:/home/evan/resources/0verkill/data.h:170: first defined here
/usr/bin/ld: hash.o:/home/evan/resources/0verkill/data.h:142: multiple definition of `weapon_name'; server.o:/home/evan/resources/0verkill/data.h:142: first defined here
/usr/bin/ld: error.o:/home/evan/resources/0verkill/data.h:185: multiple definition of `weapon'; server.o:/home/evan/resources/0verkill/data.h:185: first defined here
/usr/bin/ld: error.o:/home/evan/resources/0verkill/data.h:170: multiple definition of `obj_attr'; server.o:/home/evan/resources/0verkill/data.h:170: first defined here
/usr/bin/ld: error.o:/home/evan/resources/0verkill/data.h:142: multiple definition of `weapon_name'; server.o:/home/evan/resources/0verkill/data.h:142: first defined here
collect2: error: ld returned 1 exit status
make: *** [Makefile:98: server] Error 1
```

Adding `-fcommon` to the CFLAGS fixes this.