### PR TITLE
Add extern to declarations in order to remove -fcommon

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -19,7 +19,7 @@ oldincludedir = @oldincludedir@
 pdfdir = @pdfdir@
 prefix = @prefix@
 BASEDIR=@datadir@/0verkill
-CFLAGS += @CFLAGS@ -O3 @X_CFLAGS@ -DBASE_DIR="\"$(BASEDIR)\"" -Wall -W -Wstrict-prototypes -Wno-parentheses -fcommon
+CFLAGS += @CFLAGS@ -O3 @X_CFLAGS@ -DBASE_DIR="\"$(BASEDIR)\"" -Wall -W -Wstrict-prototypes -Wno-parentheses
 #-malign-functions=0
 LDFLAGS?=@LDFLAGS@
 LIBS=@LIBS@ 

--- a/bot.c
+++ b/bot.c
@@ -107,7 +107,7 @@ static struct sockaddr_in server;  /* server address */
 
 /* objects */
 static struct object_list objects;
-struct object_list *last_obj;
+extern struct object_list *last_obj;
 static struct it* hero;
 
 static unsigned long_long game_start_offset; /* time difference between game start on this machine and on server */

--- a/client.c
+++ b/client.c
@@ -120,7 +120,7 @@ struct sockaddr_in server;  /* server address */
 
 /* objects */
 struct object_list objects;
-struct object_list *last_obj;
+extern struct object_list *last_obj;
 struct it* hero;
 
 /* important sprites */

--- a/data.c
+++ b/data.c
@@ -25,6 +25,10 @@ int tri_d = 0;
 int TRI_D_ON = 0;
 #endif
 
+/* see data.h */
+unsigned char *weapon_name[ARMS];
+struct obj_attr_type obj_attr[N_TYPES];
+struct weapon_type weapon[ARMS];
 
 /* static map of the level */
 unsigned char *area;

--- a/data.h
+++ b/data.h
@@ -139,7 +139,7 @@
 
 #define ARMS 8
 
-unsigned char *weapon_name[ARMS];
+extern unsigned char *weapon_name[ARMS];
 
 /* STATUS
 0: walk
@@ -156,7 +156,7 @@ unsigned char *weapon_name[ARMS];
 
 
 /* object attribute table */
-struct obj_attr_type {
+extern struct obj_attr_type {
   unsigned char fall;   /* 1=can fall, 0=can't */
   int bounce_x,bounce_y;  /* slow down during horizontal/vertical bouncing */
   int slow_down_x;   /* slow down when not falling, speed is multiplied with this constant */
@@ -171,7 +171,7 @@ struct obj_attr_type {
 
 
 /* weapon attribut table */
-struct weapon_type {
+extern struct weapon_type {
   char *name;
   unsigned char cadence;
   int ttl:16;

--- a/editor.c
+++ b/editor.c
@@ -26,7 +26,7 @@ int x = 0, y = 0;  /* cursor coordinates on the screen */
 int oldx = 0, oldy = 0;  /* old cursor position */
 
 struct object_list objects;
-struct object_list *last_obj;
+extern struct object_list *last_obj;
 int level_number;
 
 

--- a/server.c
+++ b/server.c
@@ -104,7 +104,7 @@ struct queue_list
 struct object_list objects;
 
 struct player_list *last_player;
-struct object_list *last_obj;
+extern struct object_list *last_obj;
 
 
 #ifdef WIN32


### PR DESCRIPTION
The current fix for modern versions of gcc simply adds `-fcommon` to `CFLAGS` (added in #1). This pull request adds `extern` to several variable declarations so that isn't necessary anymore. I've tested it lightly (server, bot, and client), and everything seems to work, but it isn't always entirely clear which variables are actually supposed to be global and which aren't in this codebase, so I hope I didn't accidentally break anything.